### PR TITLE
docs: clarify who is supporting

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -32,7 +32,7 @@ The currently active layout is switchable using Control-spacebar.
 
 ## Limitations
 
-Only the main layout arrangments are supported. Modifier keys, backspace, AltGr layers etc remain as per the defaults. Extend layer is not supported.
+Only the main layout arrangments are supported by the Android API. Modifier keys, backspace, AltGr layers etc remain as per the defaults. Extend layer is not supported.
 
 ## Making modifications
 


### PR DESCRIPTION
Or is it just not supported by the authors of this repo? 

I don't mind compiling my own APK but I don't want to invest time into installing android-tools all over again (I still have the nightmares) if remapping caps lock to backspace is not technically possible