### PR TITLE
Add Instruction to Install on macOS using Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ There is a project implementing [EurKEY Colemak-DH](https://gitlab.com/jungganz/
 
 Colemak-DH mappings for macOS have been contributed in the ![download](gfx/arrow-circle-down.png)[**macOS folder**](macOS/)
 
+### Homebrew
+
+Homebrew user can use the following command to install Colemak-DH to macOS:
+
+```sh
+brew install --cask colemak-dh # Install Colemak-DH
+brew install --cask colemak-dhk # Install Colemak-DHk
+```
+
 # Cross platform (Windows, Linux, Mac)
 
 ### KMonad configurations


### PR DESCRIPTION
Both Colemak-DH and Colemak-DHk has been added to Homebrew cask (https://github.com/Homebrew/homebrew-cask/pull/187602) and can now use Homebrew to install the keyboard layout:

- [formulae.brew.sh/cask/colemak-dh](https://formulae.brew.sh/cask/colemak-dh)
- [formulae.brew.sh/cask/colemak-dhk](https://formulae.brew.sh/cask/colemak-dhk)

Adding the instruction inside this repository will let Homebrew user know that they can also install the layout using Homebrew.